### PR TITLE
Allow rom.py to accept headered JP 1.0 Roms

### DIFF
--- a/pyz3r/rom.py
+++ b/pyz3r/rom.py
@@ -18,21 +18,20 @@ class romfile:
             list -- A list of bytes depicting the read ROM file.
         """
 
+        fr = open(srcfilepath,"rb").read()
+        expected_rom_sha256='794e040b02c7591b59ad8843b51e7c619b88f87cddc6083a8e7a4027b96a2271'
+        if verify_checksum and len(list(fr)) == 1049088:
+            fr = bytes(list(fr[512:]))
         if verify_checksum:
-            expected_rom_sha256='794e040b02c7591b59ad8843b51e7c619b88f87cddc6083a8e7a4027b96a2271'
             sha256_hash = hashlib.sha256()
-            with open(srcfilepath,"rb") as f:
-                for byte_block in iter(lambda: f.read(4096),b""):
-                    sha256_hash.update(byte_block)
+            sha256_hash.update(fr)
             if not sha256_hash.hexdigest() == expected_rom_sha256:
                 raise alttprException('Expected checksum "{expected_rom_sha256}", got "{actual_checksum}" instead.  Verify the source ROM is an unheadered Japan 1.0 Link to the Past ROM.'.format(
                     expected_rom_sha256=expected_rom_sha256,
                     actual_checksum=sha256_hash.hexdigest()
                 ))
-        fr = open(srcfilepath,"rb")
-        baserom_array = list(fr.read())
-        fr.close()
-        return baserom_array
+        baserom_array = list(fr)
+        return baserom_array 
 
     def write(rom, dstfilepath):
         """Writes a list of bytes to a file on the filesystem.

--- a/pyz3r/rom.py
+++ b/pyz3r/rom.py
@@ -20,9 +20,9 @@ class romfile:
 
         fr = open(srcfilepath,"rb").read()
         baserom_array = list(fr)
-        if verify_checksum and len(baserom_array) == 1049088:
-            baserom_array = baserom_array[512:]
         if verify_checksum:
+            if len(baserom_array) == 1049088:
+                baserom_array = baserom_array[512:]
             expected_rom_sha256='794e040b02c7591b59ad8843b51e7c619b88f87cddc6083a8e7a4027b96a2271'
             sha256_hash = hashlib.sha256()
             sha256_hash.update(bytes(baserom_array))

--- a/pyz3r/rom.py
+++ b/pyz3r/rom.py
@@ -19,10 +19,11 @@ class romfile:
         """
 
         fr = open(srcfilepath,"rb").read()
-        expected_rom_sha256='794e040b02c7591b59ad8843b51e7c619b88f87cddc6083a8e7a4027b96a2271'
-        if verify_checksum and len(list(fr)) == 1049088:
-            fr = bytes(list(fr[512:]))
+        baserom_array = list(fr)
+        if verify_checksum and len(baserom_array) == 1049088:
+            fr = bytes(baserom_array[512:])
         if verify_checksum:
+            expected_rom_sha256='794e040b02c7591b59ad8843b51e7c619b88f87cddc6083a8e7a4027b96a2271'
             sha256_hash = hashlib.sha256()
             sha256_hash.update(fr)
             if not sha256_hash.hexdigest() == expected_rom_sha256:
@@ -30,7 +31,6 @@ class romfile:
                     expected_rom_sha256=expected_rom_sha256,
                     actual_checksum=sha256_hash.hexdigest()
                 ))
-        baserom_array = list(fr)
         return baserom_array 
 
     def write(rom, dstfilepath):

--- a/pyz3r/rom.py
+++ b/pyz3r/rom.py
@@ -21,11 +21,11 @@ class romfile:
         fr = open(srcfilepath,"rb").read()
         baserom_array = list(fr)
         if verify_checksum and len(baserom_array) == 1049088:
-            fr = bytes(baserom_array[512:])
+            baserom_array = baserom_array[512:]
         if verify_checksum:
             expected_rom_sha256='794e040b02c7591b59ad8843b51e7c619b88f87cddc6083a8e7a4027b96a2271'
             sha256_hash = hashlib.sha256()
-            sha256_hash.update(fr)
+            sha256_hash.update(bytes(baserom_array))
             if not sha256_hash.hexdigest() == expected_rom_sha256:
                 raise alttprException('Expected checksum "{expected_rom_sha256}", got "{actual_checksum}" instead.  Verify the source ROM is an unheadered Japan 1.0 Link to the Past ROM.'.format(
                     expected_rom_sha256=expected_rom_sha256,


### PR DESCRIPTION
I adjusted the read method in rom.py to check if the rom has a header based on size. If it does, the header bytes are stripped and then the hash comparison is made. Tested with JP 1.0 headered and unheadered, and a separate headered rom. 

The other main difference is that the rom file is opened and read into memory at the beginning of the function and not explicitly closed. 