### PR TITLE
Let async patcher strip headered JP 1.0 rom

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 base_rom/
 outputs/
+venv/
 
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/pyz3r/async_rom.py
+++ b/pyz3r/async_rom.py
@@ -18,20 +18,19 @@ class romfile:
         Returns:
             list -- A list of bytes depicting the read ROM file.
         """
+        async with aiofiles.open(srcfilepath,"rb") as f:
+            baserom_array = list(await f.read())
         if verify_checksum:
+            if len(baserom_array) == 1049088:
+                baserom_array = baserom_array[512:]
             expected_rom_sha256='794e040b02c7591b59ad8843b51e7c619b88f87cddc6083a8e7a4027b96a2271'
             sha256_hash = hashlib.sha256()
-            with open(srcfilepath,"rb") as f:
-                for byte_block in iter(lambda: f.read(4096),b""):
-                    sha256_hash.update(byte_block)
+            sha256_hash.update(bytes(baserom_array))
             if not sha256_hash.hexdigest() == expected_rom_sha256:
                 raise alttprException('Expected checksum "{expected_rom_sha256}", got "{actual_checksum}" instead.  Verify the source ROM is an unheadered Japan 1.0 Link to the Past ROM.'.format(
                     expected_rom_sha256=expected_rom_sha256,
                     actual_checksum=sha256_hash.hexdigest()
                 ))
-        fr = await aiofiles.open(srcfilepath,"rb")
-        baserom_array = list(await fr.read())
-        await fr.close()
         return baserom_array
 
     async def write(rom, dstfilepath):

--- a/pyz3r/rom.py
+++ b/pyz3r/rom.py
@@ -17,8 +17,8 @@ class romfile:
         Returns:
             list -- A list of bytes depicting the read ROM file.
         """
-
-        fr = open(srcfilepath,"rb").read()
+        with open(srcfilepath,"rb") as f:
+            fr = f.read()
         baserom_array = list(fr)
         if verify_checksum:
             if len(baserom_array) == 1049088:

--- a/pyz3r/rom.py
+++ b/pyz3r/rom.py
@@ -18,12 +18,10 @@ class romfile:
             list -- A list of bytes depicting the read ROM file.
         """
 
-        headered = False
         fr = open(srcfilepath,"rb").read()
         expected_rom_sha256='794e040b02c7591b59ad8843b51e7c619b88f87cddc6083a8e7a4027b96a2271'
         if verify_checksum and len(list(fr)) == 1049088:
             fr = bytes(list(fr[512:]))
-            headered = True
         if verify_checksum:
             sha256_hash = hashlib.sha256()
             sha256_hash.update(fr)
@@ -33,7 +31,7 @@ class romfile:
                     actual_checksum=sha256_hash.hexdigest()
                 ))
         baserom_array = list(fr)
-        return baserom_array #headered
+        return baserom_array 
 
     def write(rom, dstfilepath):
         """Writes a list of bytes to a file on the filesystem.

--- a/pyz3r/rom.py
+++ b/pyz3r/rom.py
@@ -18,8 +18,7 @@ class romfile:
             list -- A list of bytes depicting the read ROM file.
         """
         with open(srcfilepath,"rb") as f:
-            fr = f.read()
-        baserom_array = list(fr)
+            baserom_array = list(f.read())
         if verify_checksum:
             if len(baserom_array) == 1049088:
                 baserom_array = baserom_array[512:]

--- a/pyz3r/rom.py
+++ b/pyz3r/rom.py
@@ -18,21 +18,22 @@ class romfile:
             list -- A list of bytes depicting the read ROM file.
         """
 
+        headered = False
+        fr = open(srcfilepath,"rb").read()
+        expected_rom_sha256='794e040b02c7591b59ad8843b51e7c619b88f87cddc6083a8e7a4027b96a2271'
+        if verify_checksum and len(list(fr)) == 1049088:
+            fr = bytes(list(fr[512:]))
+            headered = True
         if verify_checksum:
-            expected_rom_sha256='794e040b02c7591b59ad8843b51e7c619b88f87cddc6083a8e7a4027b96a2271'
             sha256_hash = hashlib.sha256()
-            with open(srcfilepath,"rb") as f:
-                for byte_block in iter(lambda: f.read(4096),b""):
-                    sha256_hash.update(byte_block)
+            sha256_hash.update(fr)
             if not sha256_hash.hexdigest() == expected_rom_sha256:
                 raise alttprException('Expected checksum "{expected_rom_sha256}", got "{actual_checksum}" instead.  Verify the source ROM is an unheadered Japan 1.0 Link to the Past ROM.'.format(
                     expected_rom_sha256=expected_rom_sha256,
                     actual_checksum=sha256_hash.hexdigest()
                 ))
-        fr = open(srcfilepath,"rb")
-        baserom_array = list(fr.read())
-        fr.close()
-        return baserom_array
+        baserom_array = list(fr)
+        return baserom_array #headered
 
     def write(rom, dstfilepath):
         """Writes a list of bytes to a file on the filesystem.

--- a/pyz3r/rom.py
+++ b/pyz3r/rom.py
@@ -23,6 +23,7 @@ class romfile:
         if verify_checksum and len(baserom_array) == 1049088:
             baserom_array = baserom_array[512:]
         if verify_checksum:
+            expected_rom_sha256='794e040b02c7591b59ad8843b51e7c619b88f87cddc6083a8e7a4027b96a2271'
             sha256_hash = hashlib.sha256()
             sha256_hash.update(bytes(baserom_array))
             if not sha256_hash.hexdigest() == expected_rom_sha256:


### PR DESCRIPTION
I adjusted the async patcher to accept a headered rom if JP 1.0. Also added the "with" statement back into both patchers. Even though I believe the garbage collector should prevent any problems, this seems to be the best practice.

Only the last two commits are relevant. Please forgive the extra commits; I'm not good with git.