### PR TITLE
Allow async ROM reader to accept headered JP 1.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+venv/
 base_rom/
 outputs/
 

--- a/pyz3r/async_rom.py
+++ b/pyz3r/async_rom.py
@@ -18,20 +18,19 @@ class romfile:
         Returns:
             list -- A list of bytes depicting the read ROM file.
         """
+        async with aiofiles.open(srcfilepath,"rb") as f:
+            baserom_array = list(await f.read())
         if verify_checksum:
+            if len(baserom_array) == 1049088:
+                baserom_array = baserom_array[512:]
             expected_rom_sha256='794e040b02c7591b59ad8843b51e7c619b88f87cddc6083a8e7a4027b96a2271'
             sha256_hash = hashlib.sha256()
-            with open(srcfilepath,"rb") as f:
-                for byte_block in iter(lambda: f.read(4096),b""):
-                    sha256_hash.update(byte_block)
+            sha256_hash.update(bytes(baserom_array))
             if not sha256_hash.hexdigest() == expected_rom_sha256:
                 raise alttprException('Expected checksum "{expected_rom_sha256}", got "{actual_checksum}" instead.  Verify the source ROM is an unheadered Japan 1.0 Link to the Past ROM.'.format(
                     expected_rom_sha256=expected_rom_sha256,
                     actual_checksum=sha256_hash.hexdigest()
                 ))
-        fr = await aiofiles.open(srcfilepath,"rb")
-        baserom_array = list(await fr.read())
-        await fr.close()
         return baserom_array
 
     async def write(rom, dstfilepath):

--- a/pyz3r/rom.py
+++ b/pyz3r/rom.py
@@ -17,9 +17,8 @@ class romfile:
         Returns:
             list -- A list of bytes depicting the read ROM file.
         """
-
-        fr = open(srcfilepath,"rb").read()
-        baserom_array = list(fr)
+        with open(srcfilepath,"rb") as f:
+            baserom_array = list(f.read())
         if verify_checksum:
             if len(baserom_array) == 1049088:
                 baserom_array = baserom_array[512:]


### PR DESCRIPTION
Sorry for submitting this twice, still learning git and wanted to clean up my commits. I adjusted the async code to accept a headered rom if JP 1.0. I Also added a "with" statement into both when loading the file.