### PR TITLE
Update for BPS base patching

### DIFF
--- a/pyz3r/alttpr.py
+++ b/pyz3r/alttpr.py
@@ -149,7 +149,7 @@ class alttprClass():
             list -- a list of dictionaries that represent a rom patch
         """
         baserom_settings = await self.site.retrieve_json("/base_rom/settings")
-        req_patch = await self.site.retrieve_json(baserom_settings['base_file'])
+        req_patch = await self.site.retrieve_binary(baserom_settings['base_file'])
         return req_patch
 
     async def create_patched_game(
@@ -184,15 +184,15 @@ class alttprClass():
             raise alttprException(
                 'Please specify a seed or hash first to generate or retrieve a game.')
 
-        # expand the ROM to size requested in seed_data
-        patchrom_array = patch.expand(
-            patchrom_array, newlenmb=self.data['size'])
-
         # apply the base modifications
-        patchrom_array = patch.apply(
+        patchrom_array = patch.apply_bps(
             rom=patchrom_array,
             patches=await self.get_patch_base()
         )
+
+        # expand the ROM to size requested in seed_data
+        patchrom_array = patch.expand(
+            patchrom_array, newlenmb=self.data['size'])
 
         # apply the seed-specific changes
         patchrom_array = patch.apply(

--- a/pyz3r/http.py
+++ b/pyz3r/http.py
@@ -77,6 +77,19 @@ class site():
         )
         return req
 
+    async def retrieve_binary(self, endpoint, useauth=True):
+        if useauth:
+            auth = self.auth
+        else:
+            auth = None
+
+        req = await request_generic(
+            url=self.site_baseurl + endpoint,
+            auth=auth,
+            returntype='binary'
+        )
+        return req
+
     async def retrieve_url_raw_content(self, url, useauth=True):
         if useauth:
             auth = self.auth

--- a/pyz3r/patch.py
+++ b/pyz3r/patch.py
@@ -1,3 +1,7 @@
+import bps.apply
+import bps.io
+import io
+
 import itertools
 from .exceptions import alttprException
 
@@ -10,7 +14,7 @@ def apply(rom, patches):
         patches {list} -- A list of dictionaries that depict of set of patches to be applied to the ROM.
 
     Returns:
-        list -- a list of bytes depicitng the patched rom
+        list -- a list of bytes depicting the patched rom
     """
     for patch in patches:
         offset = int(list(patch.keys())[0])
@@ -18,6 +22,26 @@ def apply(rom, patches):
         for idx, value in enumerate(patch_values):
             rom[offset + idx] = value
     return rom
+
+def apply_bps(rom, patches: bytes):
+    """Applies a patch, which is a bps
+
+    Arguments:
+        rom {list} -- A list of bytes depicting the ROM data to be patched.
+        patches {bytes} -- A series of bytes representing a bps patch
+
+    returns:
+        list -- a list of bytes depicting the patched rom
+    """
+    # create "files" for apply_to_files
+    # although there is an apply_to_bytearrays it does not perform CRC
+    # validation of input or output, apply_to_files does.
+    patch_file = io.BytesIO(patches)
+    source_file = io.BytesIO(bytes(rom))
+    target_file = io.BytesIO()
+
+    bps.apply.apply_to_files(patch_file, source_file, target_file)
+    return list(target_file.read())
 
 def heart_speed(speed='half'):
     """Set the low-health warning beep interval.

--- a/pyz3r/patch.py
+++ b/pyz3r/patch.py
@@ -41,6 +41,7 @@ def apply_bps(rom, patches: bytes):
     target_file = io.BytesIO()
 
     bps.apply.apply_to_files(patch_file, source_file, target_file)
+    target_file.seek(0)
     return list(target_file.read())
 
 def heart_speed(speed='half'):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 aiohttp
 aiofiles
+python-bps
 slugid


### PR DESCRIPTION
Fixes #11.  **This patch is against tag 4.8.3, which looked like the most recent tag/branch prior to removing all the patching code that broke**

Add python-bps as dependency.

Add binary get to http module.

Add apply_bps to apply module.

Reorder create_patched_game so that bps patching occurs first.  BPS
patching checks length of input and output files, so expanding romsize
at this point is not advisable.