### PR TITLE
SMVaria: Allow raise_for_status to be false for debugging purposes

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 6.0.2
+current_version = 6.0.3
 commit = True
 tag = True
 

--- a/pyz3r/__init__.py
+++ b/pyz3r/__init__.py
@@ -8,7 +8,7 @@ __title__ = 'pyz3r'
 __author__ = 'Thomas Prescott'
 __license__ = 'Apache 2.0'
 __copyright__ = 'Copyright 2018-2019 Thomas Prescott'
-__version__ = '6.0.2'
+__version__ = '6.0.3'
 
 from pyz3r.alttpr import ALTTPR
 from pyz3r.sm import sm

--- a/pyz3r/smvaria.py
+++ b/pyz3r/smvaria.py
@@ -172,7 +172,8 @@ class SuperMetroidVaria():
         seed.settings = await seed.get_settings()
 
         seed.data = await seed.generate_game(raise_for_status)
-        seed.guid = uuid.UUID(hex=seed.data['seedKey'])
+        if 'seedKey' in seed.data:
+            seed.guid = uuid.UUID(hex=seed.data['seedKey'])
 
         return seed
 

--- a/pyz3r/smvaria.py
+++ b/pyz3r/smvaria.py
@@ -130,7 +130,7 @@ class SuperMetroidVaria():
         self.auth = aiohttp.BasicAuth(login=username, password=password) if username and password else None
         self.settings_dict = settings_dict
 
-    async def generate_game(self):
+    async def generate_game(self, raise_for_status=True):
         try:
             async for attempt in AsyncRetrying(
                     stop=stop_after_attempt(3),
@@ -141,7 +141,7 @@ class SuperMetroidVaria():
                             url=f'{self.baseurl}/randomizerWebService',
                             data=self.settings,
                             auth=self.auth,
-                            raise_for_status=True) as resp:
+                            raise_for_status=raise_for_status) as resp:
                         req = await resp.json(content_type='text/html')
                     return req
         except RetryError as e:
@@ -157,6 +157,7 @@ class SuperMetroidVaria():
         username=None,
         password=None,
         settings_dict=None,
+        raise_for_status=True,
     ):
         seed = cls(
             skills_preset=skills_preset,
@@ -170,7 +171,7 @@ class SuperMetroidVaria():
 
         seed.settings = await seed.get_settings()
 
-        seed.data = await seed.generate_game()
+        seed.data = await seed.generate_game(raise_for_status)
         seed.guid = uuid.UUID(hex=seed.data['seedKey'])
 
         return seed

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ README = (HERE / "README.md").read_text()
 
 setup(
     name="pyz3r",
-    version="6.0.2",
+    version="6.0.3",
     author="Thomas Prescott",
     author_email="tcprescott@gmail.com",
     description="A python module for interacting with the web API of various randomizers, such as https://alttpr.com or https://samus.link.",


### PR DESCRIPTION
I'm making progress on a bot to generate race seeds:
https://replit.com/@idlechild123/ChoozoRaceSeedGenerator#main.py

I'm running into an issue where VARIA website is rejecting the request, and I don't know why because all I get is error 400 bad request.  However VARIA website does post an error message in the body text.  I found this thread post talking about the issue; the reason I don't get back the error message is because raise_for_status is set to true:
https://github.com/aio-libs/aiohttp/issues/3248

I'm not entirely clear on the difference between setting this true or false; I'm assuming it is set to true for a reason.  However for debugging purposes it would be helpful to set it to false.  I am seeing the error messages come back now that I have set it to false, but I had to write the aiohttp.request myself which means I'm not using pyz3r anymore... :(

I suppose I could copy-paste everything I need from the pyz3r/smvaria.py so I can debug... and potentially undo that once I figure out what is likely my own mistake... but that's going to get annoying if I need to adjust the race settings in the future and make another mistake.  I'm thinking a better solution is if pyz3r/smvaria.py had an option to override raise_for_status.